### PR TITLE
Raise actual errors in case nginx fails to start

### DIFF
--- a/tests/test_nginx.py
+++ b/tests/test_nginx.py
@@ -38,3 +38,10 @@ def test_php_hello_world(nginx_php_hello_world):
     response = requests.get(url)
     assert response.status_code == 200
     assert response.text == "Hello world! This is pytest-nginx, serving PHP!"
+
+
+nginx_bad_config_proc = factories.nginx_proc("nginx_server_root", config_template=__file__)
+
+def test_borked_config(request):
+    with pytest.raises(RuntimeError):
+        request.getfixturevalue("nginx_bad_config_proc")


### PR DESCRIPTION
With bad configuration file, nginx will start just fine, then after a few miliseconds it will exit. This time delay is not sufficient for the ``factories.daemon`` context manager to catch. This is why I implemented checking for presence of a process or a few processess this way. In case the process fails to start at some time later (after yielding it from ``factories.daemon``), the problem will be caught and the exception will be risen.

Rationale: when running current codebase on darwin, even with installed nginx, tests just stall. No exception, no error message, no nothing, it just waits (in wait_for_socket function).

Thanks for a pretty cool package, again!